### PR TITLE
Fix case-only renames on case-insensitive FS

### DIFF
--- a/code/src/stash.ts
+++ b/code/src/stash.ts
@@ -14,7 +14,7 @@ import {
 } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { hostname } from "node:os";
-import { dirname, join, relative } from "node:path";
+import { basename, dirname, join, relative } from "node:path";
 import { pipeline } from "node:stream/promises";
 import { Emitter } from "./emitter.ts";
 import { PushConflictError, SyncLockError } from "./errors.ts";
@@ -546,7 +546,14 @@ export class Stash extends Emitter<StashEvents> {
     expectedHashes: Map<string, string | null>,
   ): Promise<Set<string>> {
     const skippedWritePaths = new Set<string>();
-    for (const mutation of mutations) {
+    // Process deletes before writes so case-only renames on
+    // case-insensitive filesystems don't delete a just-written file.
+    const ordered = [...mutations].sort((a, b) => {
+      const aIsDelete = a.disk === "delete" ? 0 : 1;
+      const bIsDelete = b.disk === "delete" ? 0 : 1;
+      return aIsDelete - bIsDelete;
+    });
+    for (const mutation of ordered) {
       let diskAction = mutation.disk;
       if (diskAction === "write") {
         const expectedHash = expectedHashes.get(mutation.path) ?? null;
@@ -676,9 +683,28 @@ export class Stash extends Emitter<StashEvents> {
     return this.currentHash(path) !== expectedHash;
   }
 
+  private hasExactCasing(relPath: string): boolean {
+    const segments = relPath.split("/");
+    let current = this.dir;
+    for (const segment of segments) {
+      const entries = readdirSync(current);
+      const actual = entries.find(
+        (entry) => entry.toLowerCase() === segment.toLowerCase(),
+      );
+      if (!actual || actual !== segment) {
+        return false;
+      }
+      current = join(current, actual);
+    }
+    return true;
+  }
+
   private currentHash(path: string): string | null {
     const absPath = this.abs(path);
     if (!existsSync(absPath)) {
+      return null;
+    }
+    if (!this.hasExactCasing(path)) {
       return null;
     }
     const stat = lstatSync(absPath);

--- a/code/tests/e2e/stash-github-scenarios.e2e.test.ts
+++ b/code/tests/e2e/stash-github-scenarios.e2e.test.ts
@@ -7,6 +7,7 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  rename,
   rm,
   symlink,
   unlink,
@@ -948,6 +949,41 @@ test("scenario 32: first sync with identical local and remote content skips redu
 
     await syncWithRetry(stash);
     assert.equal(await readFile(join(machine, "hello.md"), "utf8"), "hello");
+  } finally {
+    if (repo) await deleteRepo(repo.fullName);
+    await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })));
+  }
+});
+
+test("scenario 36: case-only rename syncs to remote and back", E2E_OPTIONS, async () => {
+  let repo: RepoInfo | null = null;
+  const dirs: string[] = [];
+  try {
+    const result = await setupTwoMachineBaseline({
+      "notes/Arabella.md": "hello",
+    });
+    repo = result.repo;
+    dirs.push(...result.dirs);
+    const { machineA, machineB } = result;
+
+    // Machine A: rename to lowercase (two-step for case-insensitive FS)
+    const tmp = join(machineA.dir, "notes", "Arabella.md.tmp");
+    await rename(join(machineA.dir, "notes", "Arabella.md"), tmp);
+    await rename(tmp, join(machineA.dir, "notes", "arabella.md"));
+
+    await syncWithRetry(machineA.stash);
+
+    // Verify remote has new-case file, not old-case
+    assert.equal(await remoteFileExists(repo.fullName, "notes/arabella.md"), true);
+    assert.equal(await readRemoteText(repo.fullName, "notes/arabella.md"), "hello");
+    assert.equal(await remoteFileExists(repo.fullName, "notes/Arabella.md"), false);
+
+    // Machine B: sync should pull the rename
+    await syncWithRetry(machineB.stash);
+    assert.equal(
+      await readFile(join(machineB.dir, "notes", "arabella.md"), "utf8"),
+      "hello",
+    );
   } finally {
     if (repo) await deleteRepo(repo.fullName);
     await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })));

--- a/code/tests/integration/stash-sync.test.ts
+++ b/code/tests/integration/stash-sync.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { existsSync } from "node:fs";
-import { readFile, unlink } from "node:fs/promises";
+import { readFile, rename, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { hashBuffer } from "../../src/utils/hash.ts";
 import { PushConflictError, SyncLockError } from "../../src/errors.ts";
@@ -450,4 +450,95 @@ test("sync: drift retries are bounded and failed cycle does not apply/save", asy
     await readFile(join(dir, ".stash", "snapshot.json"), "utf8"),
   );
   assert.deepEqual(afterSnapshot, beforeSnapshot);
+});
+
+test("sync: case-only rename syncs successfully", async () => {
+  const fake = new FakeProvider();
+  const { stash, dir } = await makeStash(
+    { "notes/Arabella.md": "hello" },
+    { providers: fakeRegistry(fake) },
+  );
+  await stash.connect("fake", { repo: "r" });
+  await stash.sync();
+
+  // Rename to lowercase on disk (two-step for case-insensitive FS)
+  const tmp = join(dir, "notes", "Arabella.md.tmp");
+  await rename(join(dir, "notes", "Arabella.md"), tmp);
+  await rename(tmp, join(dir, "notes", "arabella.md"));
+
+  await stash.sync();
+
+  // Remote should have the new-case file
+  assert.equal(fake.files.has("notes/arabella.md"), true);
+  assert.equal(fake.files.get("notes/arabella.md"), "hello");
+  // Old-case path should be gone from remote
+  assert.equal(fake.files.has("notes/Arabella.md"), false);
+  // Snapshot updated to new casing
+  const snapshot = JSON.parse(
+    await readFile(join(dir, ".stash", "snapshot.json"), "utf8"),
+  );
+  assert.ok(snapshot["notes/arabella.md"]);
+  assert.equal(snapshot["notes/Arabella.md"], undefined);
+});
+
+test("sync: case-only rename with content change syncs successfully", async () => {
+  const fake = new FakeProvider();
+  const { stash, dir } = await makeStash(
+    { "notes/Arabella.md": "v1" },
+    { providers: fakeRegistry(fake) },
+  );
+  await stash.connect("fake", { repo: "r" });
+  await stash.sync();
+
+  // Rename and change content
+  const tmp = join(dir, "notes", "Arabella.md.tmp");
+  await rename(join(dir, "notes", "Arabella.md"), tmp);
+  await rename(tmp, join(dir, "notes", "arabella.md"));
+  await writeFiles(dir, { "notes/arabella.md": "v2" });
+
+  await stash.sync();
+
+  assert.equal(fake.files.get("notes/arabella.md"), "v2");
+  assert.equal(fake.files.has("notes/Arabella.md"), false);
+});
+
+test("sync: case-only rename does not trigger drift retry", async () => {
+  const fake = new FakeProvider();
+  const { stash, dir } = await makeStash(
+    { "notes/Arabella.md": "hello" },
+    { providers: fakeRegistry(fake) },
+  );
+  await stash.connect("fake", { repo: "r" });
+  await stash.sync();
+  fake.fetchCalls = 0;
+
+  const tmp = join(dir, "notes", "Arabella.md.tmp");
+  await rename(join(dir, "notes", "Arabella.md"), tmp);
+  await rename(tmp, join(dir, "notes", "arabella.md"));
+
+  await stash.sync();
+
+  // Only 1 fetch call — no drift retries
+  assert.equal(fake.fetchCalls, 1);
+});
+
+test("sync: true deletion still works alongside casing check", async () => {
+  const fake = new FakeProvider();
+  const { stash, dir } = await makeStash(
+    { "notes/Arabella.md": "hello", "other.md": "keep" },
+    { providers: fakeRegistry(fake) },
+  );
+  await stash.connect("fake", { repo: "r" });
+  await stash.sync();
+
+  await unlink(join(dir, "notes", "Arabella.md"));
+
+  await stash.sync();
+
+  assert.equal(fake.files.has("notes/Arabella.md"), false);
+  assert.equal(fake.files.get("other.md"), "keep");
+  const snapshot = JSON.parse(
+    await readFile(join(dir, ".stash", "snapshot.json"), "utf8"),
+  );
+  assert.equal(snapshot["notes/Arabella.md"], undefined);
 });

--- a/spec/.changesets/20260305-case-insensitive-drift.md
+++ b/spec/.changesets/20260305-case-insensitive-drift.md
@@ -1,0 +1,122 @@
+# Case-only renames cause unresolvable drift on case-insensitive filesystems
+
+## Problem
+
+On macOS (case-insensitive HFS+/APFS), renaming a file's case (e.g. `Arabella.md` → `arabella.md`) causes `stash sync` to fail with `local files changed during sync` on every attempt, with no way to self-resolve.
+
+`scan()` walks the directory and gets the actual disk casing (`arabella.md`). The snapshot has `Arabella.md`. Scan reports `Arabella.md` as deleted and `arabella.md` as added — this is correct. Reconcile creates mutations for both paths — also correct.
+
+The bug is in `currentHash()`. `buildExpectedHashes` sets expected hash for `Arabella.md` to `null` (locally deleted). But `currentHash("Arabella.md")` calls `existsSync()`, which returns `true` on macOS because the filesystem resolves `Arabella.md` to `arabella.md`. So it reads the file and returns a real hash. `null !== real_hash` → drift detected → retry × 5 → throws.
+
+The file `Arabella.md` does not exist. `arabella.md` exists. `existsSync` lies on case-insensitive filesystems.
+
+## Solution
+
+Make `currentHash` verify exact filename casing before returning a hash. If `existsSync` finds a file but the actual filename on disk has different casing, return `null` — that exact path doesn't exist.
+
+This check runs unconditionally (no filesystem detection needed). On case-sensitive filesystems `existsSync` already returns `false` for mismatched case, so the casing check never triggers — it's a no-op.
+
+```typescript
+/**
+ * Check whether every segment of a relative path matches the actual
+ * casing on disk. Returns false if any segment (directory or file)
+ * has different casing than what the filesystem reports.
+ */
+private hasExactCasing(relPath: string): boolean {
+  const segments = relPath.split("/");
+  let current = this.dir;
+  for (const segment of segments) {
+    const entries = readdirSync(current);
+    const actual = entries.find(
+      (entry) => entry.toLowerCase() === segment.toLowerCase(),
+    );
+    if (!actual || actual !== segment) {
+      return false;
+    }
+    current = join(current, actual);
+  }
+  return true;
+}
+
+private currentHash(path: string): string | null {
+  const absPath = this.abs(path);
+  if (!existsSync(absPath)) {
+    return null;
+  }
+  // Verify exact casing for every path segment. existsSync resolves
+  // case-insensitively on macOS, so "Research/Arabella.md" returns
+  // true even when disk has "research/arabella.md".
+  if (!this.hasExactCasing(path)) {
+    return null;
+  }
+  const stat = lstatSync(absPath);
+  if (!stat.isFile()) {
+    return NON_FILE_HASH;
+  }
+  return hashBuffer(readFileSync(absPath));
+}
+```
+
+`currentHash("Arabella.md")` now returns `null` when disk has `arabella.md`. The expected hash from `buildExpectedHashes` is `null`. Drift check passes.
+
+Additionally, `apply()` must process delete mutations before write mutations. On case-insensitive filesystems, a case-only rename produces both a delete (`Arabella.md`) and a write (`arabella.md`). If the write happens first, it overwrites the existing file (same inode on case-insensitive FS), then the delete removes the just-written file. Reordering deletes before writes avoids this.
+
+## Targets
+
+### `code/src/stash.ts`
+
+1. Add `hasExactCasing()` — verifies exact casing for each segment of a relative path against the directory listing.
+2. Update `currentHash` to call `hasExactCasing` and return `null` when casing doesn't match.
+3. Update `apply()` to process delete mutations before write mutations.
+
+### `spec/stash.md`
+
+1. Note that `currentHash` verifies exact path casing to handle case-insensitive filesystems.
+2. Note that `apply()` processes deletes before writes.
+
+## Tests
+
+### Integration tests (`stash-sync.test.ts`)
+
+These use FakeProvider and run on the local filesystem, so they naturally exercise case-insensitive behavior on macOS.
+
+```
+1. sync: case-only rename syncs successfully
+   - Stash with snapshot containing "notes/Arabella.md"
+   - Rename file on disk to "notes/arabella.md" (same content)
+   - sync()
+   - Remote receives delete for old path, write for new path
+   - Local snapshot updated with new-case path
+   - No error thrown
+
+2. sync: case-only rename with content change syncs successfully
+   - Stash with snapshot containing "notes/Arabella.md" (content "v1")
+   - Rename to "notes/arabella.md" and change content to "v2"
+   - sync()
+   - Remote receives delete for old path, write for new path with "v2"
+   - Local snapshot updated
+
+3. sync: case-only rename does not trigger drift retry
+   - Verify fetchCalls === 1 (no retries needed)
+
+4. sync: true deletion still works on case-insensitive FS
+   - Delete a file entirely (not rename)
+   - sync()
+   - Remote receives delete, snapshot updated
+```
+
+### E2E tests (`stash-github-scenarios.e2e.test.ts`)
+
+```
+5. scenario: case-only rename syncs to remote and back
+   - Machine A: create repo, sync "notes/Arabella.md" with content "hello"
+   - Machine A: rename to "notes/arabella.md" on disk (same content)
+   - Machine A: sync() — should succeed, not throw drift error
+   - Verify remote has "notes/arabella.md" and no "notes/Arabella.md"
+   - Machine B: connect to same repo, sync()
+   - Verify Machine B has "notes/arabella.md" with content "hello"
+```
+
+## Refs
+
+- GitHub issue: https://github.com/telepath-computer/stash/issues/9

--- a/spec/stash.md
+++ b/spec/stash.md
@@ -212,13 +212,15 @@ Failure contract: when that bound is exceeded, `sync()` throws the last error an
 5. **Pre-push drift check**: re-read only mutation-target paths (targeted hash checks, not a full directory scan). If any target path drifted since step 1, restart from step 1 (max 5 attempts).
 6. **Push to remote**: build `PushPayload` from mutations + new `snapshot.json`, call `provider.push(payload)`. Skip if the payload has no file writes or deletions **and** the snapshot hasn't changed — nothing to commit. If the snapshot changed (e.g. first sync establishing the baseline), a snapshot-only commit is pushed even with no file changes. On `PushConflictError` → retry from step 2 with fresh remote data.
 7. **Pre-apply drift check**: before writing each `disk: "write"` mutation, verify that path still matches the state used for reconcile. If drift is detected, skip that local write (do not overwrite) and continue the cycle.
-8. **Apply to disk**: `apply(mutations, provider)` — write/delete files, emit mutation events. For binary files where `source: "remote"`, calls `provider.get(path)` and pipes to disk.
+8. **Apply to disk**: `apply(mutations, provider)` — delete then write files, emit mutation events. Deletes are processed before writes to handle case-only renames on case-insensitive filesystems (where a write and delete to different-cased paths target the same file). For binary files where `source: "remote"`, calls `provider.get(path)` and pipes to disk.
 9. **Save snapshots**: `saveSnapshot(snapshot, mutations)` — write `snapshot.json` + text files to `snapshot.local/`
 10. **Release sync lock**: clear in-process flag and delete `.stash/sync.lock` in `finally`
 
 Push happens before local disk writes. If push fails, no local state has been modified — safe to retry or abort. If push succeeds but local writes fail (unlikely — disk full, permissions), next sync self-heals: remote has the correct state, stale local snapshot triggers a re-pull.
 
 Race handling: local files may change while sync is in flight. Drift checks are path-targeted (per mutation path), not full rescans. Pre-push drift restarts the cycle with a fresh scan (bounded to 5 attempts). Post-push drift does not restart; drifted local writes are skipped so newer local edits are preserved and converge on a later sync.
+
+Case-insensitive filesystems: drift checks verify exact filename casing for each path segment before returning a hash. On case-insensitive filesystems (e.g. macOS APFS), `existsSync("Arabella.md")` returns `true` even when disk has `arabella.md`. The drift check detects this casing mismatch and returns `null` — the file does not exist at that exact path. This prevents false drift detection when files are renamed with only a case change.
 
 Snapshot guarantee: `snapshot.json` and `snapshot.local/` represent the synchronized state for that cycle, except paths skipped by post-push drift protection. For skipped paths, local snapshot entries intentionally remain at the prior base so the next sync treats both sides as changed and re-merges. They are not a lock on future disk state — files may change immediately after apply/save, and those newer local edits are picked up on the next sync.
 

--- a/spec/tests.md
+++ b/spec/tests.md
@@ -471,3 +471,18 @@ This validates retry bounds for remote-ref races and prevents infinite conflict 
 ```
 
 This validates retry bounds for local in-flight edits under sustained churn.
+
+### Sync — Case-Insensitive Filesystems
+
+#### 36. Case-only rename syncs to remote and back
+
+```
+- Machine A: sync "notes/Arabella.md" with content "hello"
+- Machine A: rename to "notes/arabella.md" on disk (same content)
+- Machine A: sync() — succeeds, no drift error
+- Verify remote has "notes/arabella.md" and no "notes/Arabella.md"
+- Machine B: sync()
+- Verify Machine B has "notes/arabella.md" with content "hello"
+```
+
+This validates that case-only renames don't trigger false drift detection on case-insensitive filesystems (e.g. macOS APFS).


### PR DESCRIPTION
## Summary

- Case-only file renames (e.g. `Arabella.md` → `arabella.md`) caused an unresolvable drift loop on macOS
- `currentHash()` now verifies exact filename casing per path segment — `existsSync` lies on case-insensitive FS
- `apply()` now processes deletes before writes to prevent write-then-delete of same inode

## Test plan

- [x] 4 new integration tests (case rename, case rename + content change, no drift retry, true deletion)
- [x] 1 new e2e test (scenario 36: case-only rename syncs to remote and back)
- [x] All 128 unit/integration tests pass
- [x] Scenario 36 e2e passes

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `sync()` drift detection and disk apply ordering; while well-tested, the new exact-casing check (directory reads per path segment) could affect edge-case path handling and performance during drift checks.
> 
> **Overview**
> Fixes macOS/case-insensitive filesystem behavior where a case-only rename (e.g. `Arabella.md` → `arabella.md`) could trigger endless "local files changed during sync" retries and fail.
> 
> `currentHash()` now returns `null` when the on-disk path’s casing doesn’t exactly match the requested relative path, preventing false drift detection; and `apply()` now processes `disk: "delete"` mutations before `disk: "write"` mutations to avoid write-then-delete of the same inode during case-only renames.
> 
> Adds targeted integration + GitHub e2e coverage for case-only renames (including rename+content change and ensuring no drift retries), and updates specs/docs (including a new changeset) to capture the case-insensitive behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b024e3e4b6a1d9528253380bd0fcd00e21410aa2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->