### PR TITLE
fix: add existsSync guard in hasExactCasing before readdirSync

### DIFF
--- a/src/stash.ts
+++ b/src/stash.ts
@@ -694,6 +694,9 @@ export class Stash extends Emitter<StashEvents> {
     const segments = relPath.split("/");
     let current = this.dir;
     for (const segment of segments) {
+      if (!existsSync(current)) {
+        return false;
+      }
       const entries = readdirSync(current);
       const actual = entries.find((entry) => entry.toLowerCase() === segment.toLowerCase());
       if (!actual || actual !== segment) {


### PR DESCRIPTION
## Summary

Adds a defensive `existsSync` guard in `hasExactCasing` before calling `readdirSync`, matching the pattern already used in `ensureDirectoryCasing`. This prevents `ENOENT` errors when parent directories do not yet exist during sync.

## Changes

- Added `existsSync(current)` check in `hasExactCasing` loop, returning `false` if a parent directory segment does not exist (instead of crashing on `readdirSync`)

## Testing

All 136 unit and integration tests pass.

Fixes telepath-computer/stash#13