### PR TITLE
Add fine-grained PAT setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,19 @@ stash connect github --repo user/repo --background
 
 You can initialize a directory explicitly with `stash init`, or let `stash connect` create `.stash/` for you automatically.
 
-You'll need a GitHub [personal access token](https://github.com/settings/tokens). A classic token needs the `repo` scope. A fine-grained token needs **Contents: Read and write** permission on the target repo.
+You'll need a GitHub personal access token. We recommend a **fine-grained token** scoped to only the repos you use with stash.
+
+### Creating a GitHub Token
+
+1. Go to [github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new)
+2. Give it a name (e.g. `stash`)
+3. Under **Repository access**, select **Only select repositories** and pick the repo(s) you'll sync
+4. Under **Repository permissions**, set **Contents** to **Read and write**
+5. Click **Generate token** and copy it
+
+Use this token when running `stash setup github`.
+
+> A classic token with the `repo` scope also works, but grants broader access than necessary.
 
 ## How It Works
 


### PR DESCRIPTION
## Summary
- Replaces the one-line token mention with step-by-step instructions for creating a fine-grained GitHub PAT
- Links directly to the token creation page
- Recommends scoping to specific repos with only Contents read/write
- Notes classic tokens as a fallback


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates GitHub token guidance; no code or runtime behavior is affected.
> 
> **Overview**
> Updates `README.md` GitHub auth instructions to **recommend fine-grained personal access tokens** and adds step-by-step guidance (with a direct link) for creating a token scoped to selected repos with **Contents: Read and write** permissions.
> 
> Also clarifies that classic `repo`-scoped tokens still work but grant broader access than necessary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8df7395094f2c4bbedf58c246d14f10915434d61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->